### PR TITLE
Add treecorr to PYTHONPATH, PATH.

### DIFF
--- a/ups/treecorr.table
+++ b/ups/treecorr.table
@@ -1,2 +1,4 @@
 setupRequired(numpy)
 setupRequired(pyyaml)
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
Neglected to do this in tickets/DM-9611.
Without these additions, the compiled binaries and Python modules
aren't actually available.